### PR TITLE
Compare numeric suffix of pre-release strings separately

### DIFF
--- a/src/Core/SemanticVersion.cs
+++ b/src/Core/SemanticVersion.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using NuGet.Resources;
 
@@ -14,6 +15,9 @@ namespace NuGet
     [TypeConverter(typeof(SemanticVersionTypeConverter))]
     public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>
     {
+        [DllImport("shlwapi.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        static extern int StrCmpLogicalW(string x, string y);
+
         private const RegexOptions _flags = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
         private static readonly Regex _semanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
         private static readonly Regex _strictSemanticVersionRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
@@ -240,7 +244,7 @@ namespace NuGet
             {
                 return -1;
             }
-            return StringComparer.OrdinalIgnoreCase.Compare(SpecialVersion, other.SpecialVersion);
+            return StrCmpLogicalW(SpecialVersion, other.SpecialVersion);
         }
 
         public static bool operator ==(SemanticVersion version1, SemanticVersion version2)


### PR DESCRIPTION
I've put together a [Nightly release channel](https://github.com/atom/atom-nightly-releases/releases) for Atom and ran into an interesting issue while trying to generate delta packages with Squirrel.Windows.  On the day that the `1.30.0-nightly10` release was being produced on VSTS I saw the build fail with the following error:

```
2018-07-19T04:51:24.8313461Z Error: Failed with exit code: 4294967295
2018-07-19T04:51:24.8313925Z Output:
2018-07-19T04:51:24.8314245Z System.IO.FileNotFoundException: The base package release does not exist
2018-07-19T04:51:24.8314666Z File name: 'D:\a\1\s\out\atom-1.30.0-nightly1-full.nupkg'
2018-07-19T04:51:24.8315221Z    at Squirrel.DeltaPackageBuilder.CreateDeltaPackage(ReleasePackage basePackage, ReleasePackage newPackage, String outputFile)
2018-07-19T04:51:24.8315990Z    at Squirrel.Update.Program.Releasify(String package, String targetDir, String packagesDir, String bootstrapperExe, String backgroundGif, String signingOpts, String baseUrl, String setupIcon, Boolean generateMsi, String frameworkVersion, Boolean generateDeltas)
2018-07-19T04:51:24.8316677Z    at Squirrel.Update.Program.executeCommandLine(String[] args)
2018-07-19T04:51:24.8317066Z    at Squirrel.Update.Program.main(String[] args)
2018-07-19T04:51:24.8317420Z    at Squirrel.Update.Program.Main(String[] args)
2018-07-19T04:51:24.8317661Z 
2018-07-19T04:51:24.8317999Z   at ChildProcess.proc.on.code (D:\a\1\s\script\node_modules\electron-winstaller\lib\spawn-promise.js:62:16)
2018-07-19T04:51:24.8318923Z   at emitTwo (events.js:126:13)
2018-07-19T04:51:24.8319275Z   at ChildProcess.emit (events.js:214:7)
2018-07-19T04:51:24.8319668Z   at maybeClose (internal/child_process.js:925:16)
2018-07-19T04:51:24.8320356Z   at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
```

After tracking it down a bit further, I found that when generating the delta nupkg, Squirrel is looking for the previous version of `1.30.0-nightly10` in the `RELEASES` file and it's choosing `1.30.0-nightly1` instead of `1.30.0-nightly9`.  This happens due to a bug in the `SemanticVersion` class of Squirrel's fork of NuGet which compares the prerelease section of the version string using an ordinal comparison.  This comparison treats `nightly10` as a string directly following `nightly1` instead of `nightly9`.

An easy fix for this issue is to leverage the native method [`StrCmpLogicalW`](http://msdn.microsoft.com/en-us/library/bb759947(VS.85).aspx) so that the numeric parts of the prerelease string are compared the same way as how Windows Explorer sorts them.

Another option would be to try and parse the prerelease string format to detect the numeric portions and compare them separately but I think that change would be more likely to introduce regressions.

I'll be sending another PR in a moment to add a test to Squirrel.Windows that verifies the new sorting behavior.

Related PR from atom/atom: https://github.com/atom/atom/pull/17723